### PR TITLE
Fix tap highlight on burger menu icon

### DIFF
--- a/_sass/_sidebar-menu.scss
+++ b/_sass/_sidebar-menu.scss
@@ -73,6 +73,7 @@
 .burgerMenu {
     display: none;
     z-index: 9999;
+    -webkit-tap-highlight-color: transparent;
     @include tablet {
         position: fixed;
         right: 0; top: 10px;


### PR DESCRIPTION
Fix tap highlight on burger menu icon
![Example](https://i.imgur.com/oI54JF9.png)
